### PR TITLE
Add dark mode toggle

### DIFF
--- a/billing/webapp/static/css/dark-mode.css
+++ b/billing/webapp/static/css/dark-mode.css
@@ -1,0 +1,26 @@
+.dark-mode body {
+    background-color: #121212;
+    color: #f8f9fa;
+}
+.dark-mode .navbar {
+    background-color: #1f1f1f !important;
+}
+.dark-mode .card,
+.dark-mode .modal-content,
+.dark-mode .table,
+.dark-mode .dropdown-menu {
+    background-color: #1e1e1e;
+    color: #f8f9fa;
+}
+.dark-mode .table thead {
+    color: #f8f9fa;
+}
+.dark-mode .bg-light {
+    background-color: #343a40 !important;
+}
+.dark-mode .text-dark {
+    color: #f8f9fa !important;
+}
+.dark-mode a {
+    color: #8ab4f8;
+}

--- a/billing/webapp/templates/base.html
+++ b/billing/webapp/templates/base.html
@@ -1,4 +1,5 @@
 <!-- billing/webapp/bill_review/templates/base.html -->
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,6 +10,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="{% static 'css/dark-mode.css' %}" rel="stylesheet">
     {% block extra_css %}{% endblock %}
 </head>
 <body>
@@ -30,6 +32,9 @@
                     <a href="{% url 'bill_review:instructions' %}" class="btn btn-outline-light">
                         <i class="bi bi-book"></i> Instructions
                     </a>
+                      <button id="darkModeToggle" class="btn btn-outline-light">
+                          <i class="bi bi-moon"></i> Dark Mode
+                      </button>
                     {% if user.is_authenticated %}
                         <a href="{% url 'logout' %}" class="btn btn-outline-light">
                             <i class="bi bi-box-arrow-right"></i> Logout
@@ -55,6 +60,18 @@
 
     <!-- Bootstrap Bundle with Popper -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        document.addEventListener("DOMContentLoaded", function () {
+            const toggle = document.getElementById("darkModeToggle");
+            if (localStorage.getItem("darkMode") === "true") {
+                document.body.classList.add("dark-mode");
+            }
+            toggle.addEventListener("click", function() {
+                document.body.classList.toggle("dark-mode");
+                localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+            });
+        });
+    </script>
     {% block extra_js %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create `dark-mode.css` with overrides
- load new stylesheet and add dark-mode toggle button in navbar
- persist preference with localStorage

## Testing
- `pytest -q`
- `pip install flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6878556b07a883219a9827c15b6f75bb