### PR TITLE
Update chart colors using CSS variables

### DIFF
--- a/billing/webapp/static/css/dark-mode.css
+++ b/billing/webapp/static/css/dark-mode.css
@@ -1,0 +1,5 @@
+:root {
+    --grid-color: rgba(255, 255, 255, 0.2);
+    --tooltip-bg: rgba(0, 0, 0, 0.85);
+    --chart-title-color: #e9ecef;
+}

--- a/billing/webapp/templates/base.html
+++ b/billing/webapp/templates/base.html
@@ -1,6 +1,7 @@
 <!-- billing/webapp/bill_review/templates/base.html -->
 <!DOCTYPE html>
 <html lang="en">
+{% load static %}
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -9,6 +10,14 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css" rel="stylesheet">
+    <style>
+        :root {
+            --grid-color: rgba(0, 0, 0, 0.1);
+            --tooltip-bg: rgba(0, 0, 0, 0.8);
+            --chart-title-color: #495057;
+        }
+    </style>
+    <link rel="stylesheet" href="{% static 'css/dark-mode.css' %}" media="(prefers-color-scheme: dark)">
     {% block extra_css %}{% endblock %}
 </head>
 <body>

--- a/billing/webapp/templates/bill_review/dashboard.html
+++ b/billing/webapp/templates/bill_review/dashboard.html
@@ -23,7 +23,7 @@
     font-size: 1.1rem;
     font-weight: 500;
     margin-bottom: 1rem;
-    color: #495057;
+    color: var(--chart-title-color);
 }
 </style>
 {% endblock %}
@@ -185,6 +185,9 @@
 {% block extra_js %}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
+    const rootStyles = getComputedStyle(document.documentElement);
+    const gridColor = rootStyles.getPropertyValue('--grid-color').trim();
+    const tooltipBg = rootStyles.getPropertyValue('--tooltip-bg').trim();
     // Initialize tooltips
     var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
     var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
@@ -201,7 +204,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 display: false
             },
             tooltip: {
-                backgroundColor: 'rgba(0, 0, 0, 0.8)',
+                backgroundColor: tooltipBg,
                 padding: 12,
                 titleFont: {
                     size: 14,
@@ -224,7 +227,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 },
                 grid: {
                     display: true,
-                    color: 'rgba(0, 0, 0, 0.1)'
+                    color: gridColor
                 }
             },
             y: {


### PR DESCRIPTION
## Summary
- load `static` in `base.html` and add CSS variables for light mode
- create `dark-mode.css` with dark-theme variable overrides
- reference the new stylesheet when the user prefers dark mode
- update dashboard chart styles to use the CSS variables
- read the variables in JS for Chart.js configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878556f74448321a933e76d265fb889