### PR TITLE
Add dark mode badge override

### DIFF
--- a/billing/webapp/bill_review/static/bill_review/css/dark-mode.css
+++ b/billing/webapp/bill_review/static/bill_review/css/dark-mode.css
@@ -1,0 +1,3 @@
+.badge.bg-warning.text-dark {
+    color: #212529;
+}

--- a/billing/webapp/templates/base.html
+++ b/billing/webapp/templates/base.html
@@ -1,4 +1,5 @@
 <!-- billing/webapp/bill_review/templates/base.html -->
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,6 +10,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="{% static 'bill_review/css/dark-mode.css' %}" rel="stylesheet">
     {% block extra_css %}{% endblock %}
 </head>
 <body>

--- a/referrals/webapp/referrals/static/referrals/css/dark-mode.css
+++ b/referrals/webapp/referrals/static/referrals/css/dark-mode.css
@@ -1,0 +1,3 @@
+.badge.bg-warning.text-dark {
+    color: #212529;
+}

--- a/referrals/webapp/templates/base.html
+++ b/referrals/webapp/templates/base.html
@@ -1,4 +1,5 @@
 <!-- monolith/referrals/webapp/templates/base.html -->
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -7,6 +8,7 @@
     <title>{% block title %}Referrals Portal{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="{% static 'referrals/css/dark-mode.css' %}" rel="stylesheet">
     <style>
         body {
             padding-top: 4.5rem;


### PR DESCRIPTION
## Summary
- add `dark-mode.css` with `.badge.bg-warning.text-dark` override
- include the stylesheet from both base templates

## Testing
- `python -m py_compile billing/webapp/bill_review/apps.py`
- `python -m py_compile referrals/webapp/referrals/models.py`

------
https://chatgpt.com/codex/tasks/task_e_6878557312fc83218607195fd0054cb4